### PR TITLE
Fix broken cisagov/pca-gophish-composition-packer build

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,4 @@
 ---
-# tasks file for pca-gophish-composition
 - name: Create the /var/pca/pca-gophish-composition directory
   ansible.builtin.file:
     mode: 0755

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -22,9 +22,9 @@
     # The extra argument is necessary on Debian 12, which correctly
     # recognizes that the local Python is externally managed
     # (i.e. managed via the system package manager and not by pip).
-    # The extra argument is understood by pip on Debian and Kali
+    # The extra argument is understood by pip on Debian 12 and Kali
     # systems, but not others.
-    extra_args: "{{ ansible_distribution is in ['Debian', 'Kali'] | ternary('--break-system-packages', omit) }}"
+    extra_args: "{{ (ansible_distribution == 'Kali' or (ansible_distribution == 'Debian' and ansible_distribution_release == 'bookworm')) | ternary('--break-system-packages', omit) }}"
     requirements: requirements.txt
 
 - name: Install packages needed by gophish-tools helper scripts


### PR DESCRIPTION
## 🗣 Description ##

This pull request modifies the Ansible code to fix [a broken cisagov/pca-gophish-composition-packer build](https://github.com/cisagov/pca-gophish-composition-packer/actions/runs/4386446490/jobs/7680638528).

## 💭 Motivation and context ##

The SystemD-enabled Docker images we use for testing update `pip` via `pip`, whereas when we build AMIs for use in AWS we only upgrade `pip` via the system package manager.  This results in a bug where Debian Bullseye understands the `--break-system-packages` CLI flag in our Molecule testing but does not when we actually build an AMI.  To avoid build failures in [cisagov/pca-gophish-composition-packer](https://github.com/cisagov/pca-gophish-composition-packer), we only use that CLI flag where it is absolutely needed.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.