### PR TITLE
Install pca-gophish-composition into a Python virtual environment

### DIFF
--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -29,7 +29,7 @@ def test_command(host, f):
     assert host.file(f).is_file
 
 
-@pytest.mark.parametrize("pkg", ["at", "jq"])
+@pytest.mark.parametrize("pkg", ["at", "jq", "python3-virtualenv"])
 def test_packages(host, pkg):
     """Test that appropriate packages were installed."""
     assert host.package(pkg).is_installed
@@ -42,4 +42,8 @@ def test_packages(host, pkg):
 @pytest.mark.parametrize("pkg", ["gophish-init"])
 def test_pip_packages(host, pkg):
     """Test that the pip packages were installed."""
-    assert pkg in host.pip.get_packages(pip_path="pip3")
+    # Note that we are using the version of pip3 in the Python virtual
+    # environment that has been created.
+    assert pkg in host.pip.get_packages(
+        pip_path="/var/pca/pca-gophish-composition/.venv/bin/pip"
+    )

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -42,7 +42,7 @@ def test_packages(host, pkg):
 @pytest.mark.parametrize("pkg", ["gophish-init"])
 def test_pip_packages(host, pkg):
     """Test that the pip packages were installed."""
-    # Note that we are using the version of pip3 in the Python virtual
+    # Note that we are using the version of pip in the Python virtual
     # environment that has been created.
     assert pkg in host.pip.get_packages(
         pip_path="/var/pca/pca-gophish-composition/.venv/bin/pip"

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -29,10 +29,19 @@ def test_command(host, f):
     assert host.file(f).is_file
 
 
-@pytest.mark.parametrize("pkg", ["at", "jq", "python3-virtualenv"])
-def test_packages(host, pkg):
+def test_packages(host):
     """Test that appropriate packages were installed."""
-    assert host.package(pkg).is_installed
+    pkgs = None
+    if (
+        host.system_info.distribution == "debian"
+        and host.system_info.codename == "buster"
+    ):
+        pkgs = ["at", "jq", "python3-virtualenv", "virtualenv"]
+    else:
+        pkgs = ["at", "jq", "python3-virtualenv"]
+
+    for pkg in pkgs:
+        assert host.package(pkg).is_installed
 
 
 # Even though the module name is gophish_init (with an underscore) in setup.py

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,8 +28,8 @@
           # at and jq are needed by the gophish-tools helper scripts
           - at
           - jq
-          # virtualenv is used by the ansible.builtin.pip module below
-          - virtualenv
+          # python3-virtualenv is used by the ansible.builtin.pip module below
+          - python3-virtualenv
     - name: Install pca-gophish-composition in a Python virtual environment
       ansible.builtin.pip:
         chdir: /var/pca/pca-gophish-composition

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,20 +20,18 @@
 
 # Install the pca-gophish-composition package in order to properly
 # install the gophish_init script
-- name: Install pca-gophish-composition via pip
-  ansible.builtin.pip:
-    chdir: /var/pca/pca-gophish-composition
-    executable: pip3
-    # The extra argument is necessary on Debian 12, which correctly
-    # recognizes that the local Python is externally managed
-    # (i.e. managed via the system package manager and not by pip).
-    # The extra argument is understood by pip on Debian 12 and Kali
-    # systems, but not others.
-    extra_args: "{{ (ansible_distribution == 'Kali' or (ansible_distribution == 'Debian' and ansible_distribution_release == 'bookworm')) | ternary('--break-system-packages', omit) }}"
-    requirements: requirements.txt
-
-- name: Install packages needed by gophish-tools helper scripts
-  ansible.builtin.package:
-    name:
-      - at
-      - jq
+- name: Install pca-gophish-composition
+  block:
+    - name: Install prerequisites
+      ansible.builtin.package:
+        name:
+          # at and jq are needed by the gophish-tools helper scripts
+          - at
+          - jq
+          # virtualenv is used by the ansible.builtin.pip module below
+          - virtualenv
+    - name: Install pca-gophish-composition in a Python virtual environment
+      ansible.builtin.pip:
+        chdir: /var/pca/pca-gophish-composition
+        requirements: requirements.txt
+        virtualenv: /var/pca/pca-gophish-composition/.venv

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,16 @@
 ---
+- name: Load var file with package names based on the OS type
+  ansible.builtin.include_vars: "{{ lookup('first_found', params) }}"
+  vars:
+    params:
+      files:
+        - "{{ ansible_distribution }}_{{ ansible_distribution_release }}.yml"
+        - "{{ ansible_distribution }}.yml"
+        - "{{ ansible_os_family }}.yml"
+        - default.yml
+      paths:
+        - "{{ role_path }}/vars"
+
 - name: Create the /var/pca/pca-gophish-composition directory
   ansible.builtin.file:
     mode: 0755
@@ -24,12 +36,7 @@
   block:
     - name: Install prerequisites
       ansible.builtin.package:
-        name:
-          # at and jq are needed by the gophish-tools helper scripts
-          - at
-          - jq
-          # python3-virtualenv is used by the ansible.builtin.pip module below
-          - python3-virtualenv
+        name: "{{ prerequisite_package_names }}"
     - name: Install pca-gophish-composition in a Python virtual environment
       ansible.builtin.pip:
         chdir: /var/pca/pca-gophish-composition

--- a/vars/Debian_buster.yml
+++ b/vars/Debian_buster.yml
@@ -1,0 +1,13 @@
+---
+# The names of the packages that must be installed as prerequisites
+# for the installation of cisagov/pca-gophish-composition
+prerequisite_package_names:
+  # at and jq are needed by the gophish-tools helper scripts
+  - at
+  - jq
+  # python3-virtualenv is used by the ansible.builtin.pip module
+  - python3-virtualenv
+  # For some reason this virtual package must be installed on Debian
+  # Buster, or else the virtualenv executable cannot be found by
+  # Ansible.
+  - virtualenv

--- a/vars/default.yml
+++ b/vars/default.yml
@@ -1,0 +1,9 @@
+---
+# The names of the packages that must be installed as prerequisites
+# for the installation of cisagov/pca-gophish-composition
+prerequisite_package_names:
+  # at and jq are needed by the gophish-tools helper scripts
+  - at
+  - jq
+  # python3-virtualenv is used by the ansible.builtin.pip module
+  - python3-virtualenv


### PR DESCRIPTION
## 🗣 Description ##

This pull request modifies the Ansible role to install pca-gophish-composition into a Python virtual environment.

## 💭 Motivation and context ##

Resolves #50.  See also cisagov/pca-gophish-composition-packer#105.  As part of the testing for cisagov/pca-gophish-composition-packer#105 I built a staging AMI with these changes, and I was able to confirm that the `pca-gophish-composition` service started up normally.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.