### PR TITLE
Remove support for outdated platform

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -199,7 +199,9 @@ jobs:
           - fedora40-systemd
           - fedora41-systemd
           - kali-systemd
-          - ubuntu-20-systemd
+          # Ubuntu Focal only offers Python 3.8, which is unsupported
+          # by cisagov/pca-gophish-composition.
+          # - ubuntu-20-systemd
           - ubuntu-22-systemd
           - ubuntu-24-systemd
         scenario:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -46,7 +46,9 @@ galaxy_info:
         - "2023"
     - name: Ubuntu
       versions:
-        - focal
+        # Ubuntu Focal only offers Python 3.8, which is unsupported by
+        # cisagov/pca-gophish-composition.
+        # - focal
         - jammy
         - noble
   role_name: pca_gophish_composition

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -170,24 +170,26 @@ platforms:
     privileged: true
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  - cgroupns_mode: host
-    command: /lib/systemd/systemd
-    image: docker.io/geerlingguy/docker-ubuntu2004-ansible:latest
-    name: ubuntu-20-systemd-amd64
-    platform: amd64
-    pre_build_image: true
-    privileged: true
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  - cgroupns_mode: host
-    command: /lib/systemd/systemd
-    image: docker.io/geerlingguy/docker-ubuntu2004-ansible:latest
-    name: ubuntu-20-systemd-arm64
-    platform: arm64
-    pre_build_image: true
-    privileged: true
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  # Ubuntu Focal only offers Python 3.8, which is unsupported by
+  # cisagov/pca-gophish-composition.
+  # - cgroupns_mode: host
+  #   command: /lib/systemd/systemd
+  #   image: docker.io/geerlingguy/docker-ubuntu2004-ansible:latest
+  #   name: ubuntu-20-systemd-amd64
+  #   platform: amd64
+  #   pre_build_image: true
+  #   privileged: true
+  #   volumes:
+  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  # - cgroupns_mode: host
+  #   command: /lib/systemd/systemd
+  #   image: docker.io/geerlingguy/docker-ubuntu2004-ansible:latest
+  #   name: ubuntu-20-systemd-arm64
+  #   platform: arm64
+  #   pre_build_image: true
+  #   privileged: true
+  #   volumes:
+  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
   - cgroupns_mode: host
     command: /lib/systemd/systemd
     image: docker.io/geerlingguy/docker-ubuntu2204-ansible:latest

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -31,14 +31,7 @@ def test_command(host, f):
 
 def test_packages(host):
     """Test that appropriate packages were installed."""
-    pkgs = None
-    if (
-        host.system_info.distribution == "debian"
-        and host.system_info.codename == "buster"
-    ):
-        pkgs = ["at", "jq", "python3-virtualenv", "virtualenv"]
-    else:
-        pkgs = ["at", "jq", "python3-virtualenv"]
+    pkgs = ["at", "jq", "python3-virtualenv"]
 
     for pkg in pkgs:
         assert host.package(pkg).is_installed


### PR DESCRIPTION
## 🗣 Description ##

This pull request removes support for the outdated Ubuntu Focal platform.

## 💭 Motivation and context ##

Ubuntu Focal only offers Python 3.8, but [cisagov/pca-gophish-composition](https://github.com/cisagov/pca-gophish-composition) requires at least Python 3.9.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

- [x] Mark Ubuntu Focal checks as not required.